### PR TITLE
Dev

### DIFF
--- a/npm/android-arm-eabi/package.json
+++ b/npm/android-arm-eabi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-android-arm-eabi",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "android"
   ],

--- a/npm/android-arm64/package.json
+++ b/npm/android-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-android-arm64",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "android"
   ],

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-darwin-arm64",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-universal/package.json
+++ b/npm/darwin-universal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-darwin-universal",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "darwin"
   ],

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-darwin-x64",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "darwin"
   ],

--- a/npm/freebsd-x64/package.json
+++ b/npm/freebsd-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-freebsd-x64",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "freebsd"
   ],

--- a/npm/linux-arm-gnueabihf/package.json
+++ b/npm/linux-arm-gnueabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-linux-arm-gnueabihf",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/npm/linux-arm-musleabihf/package.json
+++ b/npm/linux-arm-musleabihf/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-linux-arm-musleabihf",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/npm/linux-arm64-gnu/package.json
+++ b/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-linux-arm64-gnu",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/npm/linux-arm64-musl/package.json
+++ b/npm/linux-arm64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-linux-arm64-musl",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/npm/linux-riscv64-gnu/package.json
+++ b/npm/linux-riscv64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-linux-riscv64-gnu",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-gnu/package.json
+++ b/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-linux-x64-gnu",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-linux-x64-musl",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "linux"
   ],

--- a/npm/win32-arm64-msvc/package.json
+++ b/npm/win32-arm64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-win32-arm64-msvc",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "win32"
   ],

--- a/npm/win32-ia32-msvc/package.json
+++ b/npm/win32-ia32-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-win32-ia32-msvc",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "win32"
   ],

--- a/npm/win32-x64-msvc/package.json
+++ b/npm/win32-x64-msvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@btc-vision/op-vm-win32-x64-msvc",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "os": [
     "win32"
   ],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@btc-vision/op-vm",
     "description": "OP-VM executable for Bitcoin Smart Contracts",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "license": "LICENSE.MD",
     "main": "index.js",
     "types": "index.d.ts",

--- a/src/application/contract/contract_service.rs
+++ b/src/application/contract/contract_service.rs
@@ -21,7 +21,10 @@ impl ContractService {
             if e.to_string().contains("unreachable") {
                 let gas_used = runner.get_remaining_gas();
                 if gas_used == 0 {
-                    anyhow::anyhow!("out of gas")
+                    anyhow::anyhow!(
+                    "out of gas (consumed: {})",
+                    self.max_gas
+                )
                 } else {
                     let out_of_memory = runner.is_out_of_memory().unwrap_or(false);
 

--- a/src/domain/assembly_script/assembly_script.rs
+++ b/src/domain/assembly_script/assembly_script.rs
@@ -82,20 +82,31 @@ impl AssemblyScript {
             )));
         }
 
-        let header_value = header.unwrap();
+        let header_value = header.map_err(|e| {
+            Error::from_reason(format!("Failed to get header from __new: {:?}", e))
+        })?;
 
         // Set the header values
-        Self::set_u32(store, instance, header_value, pinned_buffer_value).unwrap();
-        Self::set_u32(store, instance, header_value + 4, pinned_buffer_value).unwrap();
-        Self::set_u32(store, instance, header_value + 8, buffer_size as u32).unwrap();
+        Self::set_u32(store, instance, header_value, pinned_buffer_value).map_err(|e| {
+            Error::from_reason(format!("Failed to set header value: {:?}", e))
+        })?;
+        Self::set_u32(store, instance, header_value + 4, pinned_buffer_value).map_err(|e| {
+            Error::from_reason(format!("Failed to set header value: {:?}", e))
+        })?;
+        Self::set_u32(store, instance, header_value + 8, buffer_size as u32).map_err(|e| {
+            Error::from_reason(format!("Failed to set header value: {:?}", e))
+        })?;
 
         // Write the buffer value to the contract's memory
         instance
-            .write_memory(store, pinned_buffer_value as u64, &value)
-            .unwrap();
+            .write_memory(store, pinned_buffer_value as u64, &value).map_err(|e| {
+            Error::from_reason(format!("Failed to write buffer to memory: {:?}", e))
+        })?;
 
         // Unpin the buffer
-        Self::__unpin(store, instance, pinned_buffer_value as i32).unwrap();
+        Self::__unpin(store, instance, pinned_buffer_value as i32).map_err(|e| {
+            Error::from_reason(format!("Failed to unpin buffer: {:?}", e))
+        })?;
 
         Ok(header_value as i64)
     }

--- a/src/domain/runner/constants/constants.rs
+++ b/src/domain/runner/constants/constants.rs
@@ -11,3 +11,9 @@ pub const CALL_COST: u64 = 343_000_000;
 pub const DEPLOY_COST: u64 = 2_500_000_000;
 pub const ENCODE_ADDRESS_COST: u64 = 4_000_000;
 pub const SHA256_COST: u64 = 1_000_000;
+pub const RIMD160_COST: u64 = 1_000_000;
+
+pub const INPUTS_COST: u64 = 500_000_000;
+pub const OUTPUTS_COST: u64 = 500_000_000;
+
+pub const EMIT_COST: u64 = 100_000_000;

--- a/src/domain/runner/custom_env.rs
+++ b/src/domain/runner/custom_env.rs
@@ -1,10 +1,6 @@
 use crate::domain::runner::bitcoin_network::BitcoinNetwork;
 use crate::domain::runner::{AbortData, InstanceWrapper};
-use crate::interfaces::{
-    CallOtherContractExternalFunction, ConsoleLogExternalFunction,
-    DeployFromAddressExternalFunction, StorageLoadExternalFunction,
-    StorageStoreExternalFunction,
-};
+use crate::interfaces::{CallOtherContractExternalFunction, ConsoleLogExternalFunction, DeployFromAddressExternalFunction, EmitExternalFunction, InputsExternalFunction, OutputsExternalFunction, StorageLoadExternalFunction, StorageStoreExternalFunction};
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
@@ -17,6 +13,9 @@ pub struct CustomEnv {
     pub call_other_contract_external: CallOtherContractExternalFunction,
     pub deploy_from_address_external: DeployFromAddressExternalFunction,
     pub console_log_external: ConsoleLogExternalFunction,
+    pub emit_external: EmitExternalFunction,
+    pub inputs_external: InputsExternalFunction,
+    pub outputs_external: OutputsExternalFunction,
     pub runtime: Arc<Runtime>,
 }
 
@@ -28,6 +27,9 @@ impl CustomEnv {
         call_other_contract_external: CallOtherContractExternalFunction,
         deploy_from_address_external: DeployFromAddressExternalFunction,
         console_log_external: ConsoleLogExternalFunction,
+        emit_external: EmitExternalFunction,
+        inputs_external: InputsExternalFunction,
+        outputs_external: OutputsExternalFunction,
         runtime: Arc<Runtime>,
     ) -> anyhow::Result<Self> {
         Ok(Self {
@@ -39,6 +41,9 @@ impl CustomEnv {
             call_other_contract_external,
             deploy_from_address_external,
             console_log_external,
+            emit_external,
+            inputs_external,
+            outputs_external,
             runtime,
         })
     }

--- a/src/domain/runner/import_functions.rs
+++ b/src/domain/runner/import_functions.rs
@@ -87,10 +87,10 @@ pub fn call_other_contract_import(
     let call_execution_cost_bytes = &result[0..8];
     let response = &result[8..];
 
-    let value = AssemblyScript::write_buffer(&mut store, &instance, &response, 13, 0)
-        .map_err(|_e| RuntimeError::new("Error writing buffer"))?;
+    let value = AssemblyScript::write_buffer(&mut store, &instance, &response, 13, 0).map_err(|e| RuntimeError::new(format!("Error writing buffer: {}", e)))?;
 
-    let call_execution_cost = u64::from_le_bytes(call_execution_cost_bytes.try_into().unwrap());
+    let bytes = call_execution_cost_bytes.try_into().map_err(|_e| RuntimeError::new("Error converting bytes"))?;
+    let call_execution_cost = u64::from_le_bytes(bytes);
     instance.use_gas(&mut store, call_execution_cost);
 
     Ok(value as u32)
@@ -149,7 +149,7 @@ pub fn encode_address_import(
     result.push(0);
 
     let value = AssemblyScript::write_buffer(&mut store, &instance, &result, 13, 0)
-        .map_err(|_e| RuntimeError::new("Error writing buffer"))?;
+        .map_err(|e| RuntimeError::new(format!("Error writing buffer: {}", e)))?;
 
     instance.use_gas(&mut store, ENCODE_ADDRESS_COST);
 
@@ -173,7 +173,7 @@ pub fn sha256_import(
     let result = sha256(&data)?;
 
     let value = AssemblyScript::write_buffer(&mut store, &instance, &result, 13, 0)
-        .map_err(|_e| RuntimeError::new("Error writing buffer"))?;
+        .map_err(|e| RuntimeError::new(format!("Error writing buffer: {}", e)))?;
 
     instance.use_gas(&mut store, SHA256_COST);
 
@@ -223,7 +223,7 @@ fn external_import_with_param_and_return(
     let result = external_function.execute(&data, runtime)?;
 
     let value = AssemblyScript::write_buffer(&mut store, &instance, &result, 13, 0)
-        .map_err(|_e| RuntimeError::new("Error writing buffer"))?;
+        .map_err(|e| RuntimeError::new(format!("Error writing buffer: {}", e)))?;
 
     Ok(value as u32)
 }

--- a/src/domain/runner/import_functions.rs
+++ b/src/domain/runner/import_functions.rs
@@ -5,7 +5,7 @@ use tokio::runtime::Runtime;
 use wasmer::{FunctionEnvMut, RuntimeError, StoreMut};
 
 use crate::domain::assembly_script::AssemblyScript;
-use crate::domain::runner::{AbortData, CustomEnv, CALL_COST, DEPLOY_COST, ENCODE_ADDRESS_COST, LOAD_COST, SHA256_COST, STORE_COST};
+use crate::domain::runner::{AbortData, CustomEnv, CALL_COST, DEPLOY_COST, EMIT_COST, ENCODE_ADDRESS_COST, INPUTS_COST, LOAD_COST, OUTPUTS_COST, RIMD160_COST, SHA256_COST, STORE_COST};
 use crate::interfaces::ExternalFunction;
 
 pub fn abort_import(
@@ -42,30 +42,6 @@ pub fn storage_store_import(
     external_import_with_param_and_return(env, store, &env.storage_store_external, ptr, STORE_COST, &env.runtime)
 }
 
-/*pub fn storage_store_import(
-    mut context: FunctionEnvMut<CustomEnv>,
-    ptr: u32,
-) -> Result<u32, RuntimeError> {
-    let (env, mut store) = context.data_and_store_mut();
-
-    let instance = env
-        .instance
-        .clone()
-        .ok_or(RuntimeError::new("Instance not found"))?;
-
-    instance.use_gas(&mut store, STORE_COST);
-
-    let data = AssemblyScript::read_buffer(&mut store, &instance, ptr)
-        .map_err(|_e| RuntimeError::new("Error lifting typed array"))?;
-
-    let result = env.storage_store_external.execute(&data)?;
-
-    let value = AssemblyScript::write_buffer(&mut store, &instance, &result, 13, 0)
-        .map_err(|_e| RuntimeError::new("Error writing buffer"))?;
-
-    Ok(value as u32)
-}*/
-
 pub fn call_other_contract_import(
     mut context: FunctionEnvMut<CustomEnv>,
     ptr: u32,
@@ -83,6 +59,58 @@ pub fn call_other_contract_import(
         .map_err(|_e| RuntimeError::new("Error lifting typed array"))?;
 
     let result = &env.call_other_contract_external.execute(&data, &env.runtime)?;
+
+    let call_execution_cost_bytes = &result[0..8];
+    let response = &result[8..];
+
+    let value = AssemblyScript::write_buffer(&mut store, &instance, &response, 13, 0).map_err(|e| RuntimeError::new(format!("Error writing buffer: {}", e)))?;
+
+    let bytes = call_execution_cost_bytes.try_into().map_err(|_e| RuntimeError::new("Error converting bytes"))?;
+    let call_execution_cost = u64::from_le_bytes(bytes);
+    instance.use_gas(&mut store, call_execution_cost);
+
+    Ok(value as u32)
+}
+
+pub fn inputs_import(
+    mut context: FunctionEnvMut<CustomEnv>,
+) -> Result<u32, RuntimeError> {
+    let (env, mut store) = context.data_and_store_mut();
+
+    let instance = env
+        .instance
+        .clone()
+        .ok_or(RuntimeError::new("Instance not found"))?;
+
+    instance.use_gas(&mut store, INPUTS_COST);
+
+    let result = &env.inputs_external.execute(&env.runtime)?;
+
+    let call_execution_cost_bytes = &result[0..8];
+    let response = &result[8..];
+
+    let value = AssemblyScript::write_buffer(&mut store, &instance, &response, 13, 0).map_err(|e| RuntimeError::new(format!("Error writing buffer: {}", e)))?;
+
+    let bytes = call_execution_cost_bytes.try_into().map_err(|_e| RuntimeError::new("Error converting bytes"))?;
+    let call_execution_cost = u64::from_le_bytes(bytes);
+    instance.use_gas(&mut store, call_execution_cost);
+
+    Ok(value as u32)
+}
+
+pub fn outputs_import(
+    mut context: FunctionEnvMut<CustomEnv>,
+) -> Result<u32, RuntimeError> {
+    let (env, mut store) = context.data_and_store_mut();
+
+    let instance = env
+        .instance
+        .clone()
+        .ok_or(RuntimeError::new("Instance not found"))?;
+
+    instance.use_gas(&mut store, OUTPUTS_COST);
+
+    let result = &env.outputs_external.execute(&env.runtime)?;
 
     let call_execution_cost_bytes = &result[0..8];
     let response = &result[8..];
@@ -180,8 +208,42 @@ pub fn sha256_import(
     Ok(value as u32)
 }
 
+pub fn ripemd160_import(
+    mut context: FunctionEnvMut<CustomEnv>,
+    ptr: u32,
+) -> Result<u32, RuntimeError> {
+    let (env, mut store) = context.data_and_store_mut();
+
+    let instance = env
+        .instance
+        .clone()
+        .ok_or(RuntimeError::new("Instance not found"))?;
+
+    let data = AssemblyScript::read_buffer(&store, &instance, ptr)
+        .map_err(|_e| RuntimeError::new("Error lifting typed array"))?;
+
+    let result = rimemd160(&data)?;
+
+    let value = AssemblyScript::write_buffer(&mut store, &instance, &result, 13, 0)
+        .map_err(|e| RuntimeError::new(format!("Error writing buffer: {}", e)))?;
+
+    instance.use_gas(&mut store, RIMD160_COST);
+
+    Ok(value as u32)
+}
+
 fn sha256(data: &[u8]) -> Result<Vec<u8>, RuntimeError> {
     let hash = Sha256::digest(data);
+    let hash_as_vec: Vec<u8> = hash.to_vec();
+
+    Ok(hash_as_vec)
+}
+
+fn rimemd160(data: &[u8]) -> Result<Vec<u8>, RuntimeError> {
+    let mut ripemd = Ripemd160::new();
+    ripemd.update(data);
+
+    let hash = ripemd.finalize();
     let hash_as_vec: Vec<u8> = hash.to_vec();
 
     Ok(hash_as_vec)
@@ -200,6 +262,24 @@ pub fn console_log_import(
         .map_err(|_e| RuntimeError::new("Error lifting typed array"))?;
 
     env.console_log_external.execute(&data)
+}
+
+pub fn emit_import(
+    mut context: FunctionEnvMut<CustomEnv>,
+    ptr: u32,
+) -> Result<(), RuntimeError> {
+    let (env, mut store) = context.data_and_store_mut();
+    let instance = &env
+        .instance
+        .clone()
+        .ok_or(RuntimeError::new("Memory not found"))?;
+
+    instance.use_gas(&mut store, EMIT_COST);
+
+    let data = AssemblyScript::read_buffer(&store, &instance, ptr)
+        .map_err(|_e| RuntimeError::new("Error lifting typed array"))?;
+
+    env.emit_external.execute(&data)
 }
 
 fn external_import_with_param_and_return(

--- a/src/domain/runner/wasmer_runner.rs
+++ b/src/domain/runner/wasmer_runner.rs
@@ -9,7 +9,7 @@ use wasmer_middlewares::Metering;
 use wasmer_types::{SerializeError, Target};
 
 use crate::domain::assembly_script::AssemblyScript;
-use crate::domain::runner::{abort_import, call_other_contract_import, console_log_import, deploy_from_address_import, encode_address_import, sha256_import, storage_load_import, storage_store_import, AbortData, ContractRunner, CustomEnv, InstanceWrapper};
+use crate::domain::runner::{abort_import, call_other_contract_import, console_log_import, deploy_from_address_import, emit_import, encode_address_import, inputs_import, outputs_import, ripemd160_import, sha256_import, storage_load_import, storage_store_import, AbortData, ContractRunner, CustomEnv, InstanceWrapper};
 use crate::domain::vm::{get_gas_cost, log_time_diff, LimitingTunables};
 
 use crate::domain::runner::constants::{MAX_GAS_CONSTRUCTOR, MAX_PAGES, STACK_SIZE};
@@ -100,6 +100,10 @@ impl WasmerRunner {
                 "encodeAddress" => import!(encode_address_import),
                 "sha256" => import!(sha256_import),
                 "log" => import!(console_log_import),
+                "emit" => import!(emit_import),
+                "inputs" => import!(inputs_import),
+                "outputs" => import!(outputs_import),
+                "ripemd160" => import!(ripemd160_import),
             }
         };
 

--- a/src/interfaces/napi/external_functions/emit_external_function.rs
+++ b/src/interfaces/napi/external_functions/emit_external_function.rs
@@ -1,0 +1,32 @@
+use napi::bindgen_prelude::BigInt;
+use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction, ThreadsafeFunctionCallMode};
+use wasmer::RuntimeError;
+
+use crate::interfaces::napi::thread_safe_js_import_response::ThreadSafeJsImportResponse;
+
+pub struct EmitExternalFunction {
+    tsfn: ThreadsafeFunction<ThreadSafeJsImportResponse, ErrorStrategy::CalleeHandled>,
+    id: u64,
+}
+
+impl EmitExternalFunction {
+    pub fn new(
+        tsfn: ThreadsafeFunction<ThreadSafeJsImportResponse, ErrorStrategy::CalleeHandled>,
+        id: u64,
+    ) -> Self {
+        Self { tsfn, id }
+    }
+}
+
+impl EmitExternalFunction {
+    pub(crate) fn execute(&self, data: &[u8]) -> Result<(), RuntimeError> {
+        let request = ThreadSafeJsImportResponse {
+            buffer: Vec::from(data),
+            contract_id: BigInt::from(self.id),
+        };
+
+        self.tsfn.call(Ok(request), ThreadsafeFunctionCallMode::NonBlocking);
+
+        Ok(())
+    }
+}

--- a/src/interfaces/napi/external_functions/external_function.rs
+++ b/src/interfaces/napi/external_functions/external_function.rs
@@ -4,3 +4,7 @@ use wasmer::RuntimeError;
 pub trait ExternalFunction {
     fn execute(&self, data: &[u8], runtime: &Runtime) -> Result<Vec<u8>, RuntimeError>;
 }
+
+pub trait ExternalFunctionNoData {
+    fn execute_no_data(&self, runtime: &Runtime) -> Result<Vec<u8>, RuntimeError>;
+}

--- a/src/interfaces/napi/external_functions/generic_external_function.rs
+++ b/src/interfaces/napi/external_functions/generic_external_function.rs
@@ -4,7 +4,7 @@ use tokio::runtime::Runtime;
 use wasmer::RuntimeError;
 
 use crate::interfaces::napi::thread_safe_js_import_response::ThreadSafeJsImportResponse;
-use crate::interfaces::ExternalFunction;
+use crate::interfaces::{ExternalFunction, ExternalFunctionNoData};
 
 pub struct GenericExternalFunction {
     tsfn: ThreadsafeFunction<ThreadSafeJsImportResponse, ErrorStrategy::CalleeHandled>,
@@ -24,6 +24,37 @@ impl ExternalFunction for GenericExternalFunction {
     fn execute(&self, data: &[u8], runtime: &Runtime) -> Result<Vec<u8>, RuntimeError> {
         let request = ThreadSafeJsImportResponse {
             buffer: Vec::from(data),
+            contract_id: BigInt::from(self.contract_id),
+        };
+
+        let deploy = async move {
+            let response: Result<Promise<Buffer>, RuntimeError> = self
+                .tsfn
+                .call_async(Ok(request))
+                .await
+                .map_err(|e| RuntimeError::new(e.reason));
+
+            let promise = response?;
+
+            let data = promise
+                .await
+                .map_err(|e| RuntimeError::new(e.reason))?;
+
+            let data = data.to_vec();
+
+            Ok(data.into())
+        };
+
+        let response = runtime.block_on(deploy);
+
+        response
+    }
+}
+
+impl ExternalFunctionNoData for GenericExternalFunction {
+    fn execute_no_data(&self, runtime: &Runtime) -> Result<Vec<u8>, RuntimeError> {
+        let request = ThreadSafeJsImportResponse {
+            buffer: Vec::new(),
             contract_id: BigInt::from(self.contract_id),
         };
 

--- a/src/interfaces/napi/external_functions/inputs_external_function.rs
+++ b/src/interfaces/napi/external_functions/inputs_external_function.rs
@@ -1,0 +1,28 @@
+use crate::interfaces::napi::thread_safe_js_import_response::ThreadSafeJsImportResponse;
+use crate::interfaces::{ExternalFunctionNoData, GenericExternalFunction};
+use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
+use tokio::runtime::Runtime;
+use wasmer::RuntimeError;
+
+pub struct InputsExternalFunction {
+    external_function: GenericExternalFunction,
+}
+
+impl InputsExternalFunction {
+    pub fn new(
+        tsfn: ThreadsafeFunction<ThreadSafeJsImportResponse, ErrorStrategy::CalleeHandled>,
+        id: u64,
+    ) -> Self {
+        Self {
+            external_function: GenericExternalFunction::new(tsfn, id),
+        }
+    }
+}
+
+impl InputsExternalFunction {
+    pub(crate) fn execute(&self, runtime: &Runtime) -> Result<Vec<u8>, RuntimeError> {
+        let resp = self.external_function.execute_no_data(runtime);
+
+        resp
+    }
+}

--- a/src/interfaces/napi/external_functions/mod.rs
+++ b/src/interfaces/napi/external_functions/mod.rs
@@ -1,7 +1,8 @@
 pub use self::{
     call_other_contract_external_function::*, console_log_external_function::*,
-    deploy_from_address_external_function::*, external_function::*, generic_external_function::*,
-    storage_load_external_function::*, storage_store_external_function::*,
+    deploy_from_address_external_function::*, emit_external_function::*, external_function::*,
+    generic_external_function::*, inputs_external_function::*, outputs_external_function::*, storage_load_external_function::*,
+    storage_store_external_function::*,
 };
 
 mod call_other_contract_external_function;
@@ -11,3 +12,6 @@ mod external_function;
 mod generic_external_function;
 mod storage_load_external_function;
 mod storage_store_external_function;
+mod emit_external_function;
+mod inputs_external_function;
+mod outputs_external_function;

--- a/src/interfaces/napi/external_functions/outputs_external_function.rs
+++ b/src/interfaces/napi/external_functions/outputs_external_function.rs
@@ -1,0 +1,28 @@
+use crate::interfaces::napi::thread_safe_js_import_response::ThreadSafeJsImportResponse;
+use crate::interfaces::{ExternalFunctionNoData, GenericExternalFunction};
+use napi::threadsafe_function::{ErrorStrategy, ThreadsafeFunction};
+use tokio::runtime::Runtime;
+use wasmer::RuntimeError;
+
+pub struct OutputsExternalFunction {
+    external_function: GenericExternalFunction,
+}
+
+impl OutputsExternalFunction {
+    pub fn new(
+        tsfn: ThreadsafeFunction<ThreadSafeJsImportResponse, ErrorStrategy::CalleeHandled>,
+        id: u64,
+    ) -> Self {
+        Self {
+            external_function: GenericExternalFunction::new(tsfn, id),
+        }
+    }
+}
+
+impl OutputsExternalFunction {
+    pub(crate) fn execute(&self, runtime: &Runtime) -> Result<Vec<u8>, RuntimeError> {
+        let resp = self.external_function.execute_no_data(runtime);
+
+        resp
+    }
+}

--- a/src/interfaces/napi/js_contract.rs
+++ b/src/interfaces/napi/js_contract.rs
@@ -17,11 +17,7 @@ use crate::domain::vm::log_time_diff;
 use crate::interfaces::napi::contract::JsContractParameter;
 use crate::interfaces::napi::js_contract_manager::ContractManager;
 use crate::interfaces::napi::runtime_pool::RuntimePool;
-use crate::interfaces::{
-    AbortDataResponse, CallOtherContractExternalFunction, ConsoleLogExternalFunction,
-    ContractCallTask, DeployFromAddressExternalFunction, StorageLoadExternalFunction,
-    StorageStoreExternalFunction,
-};
+use crate::interfaces::{AbortDataResponse, CallOtherContractExternalFunction, ConsoleLogExternalFunction, ContractCallTask, DeployFromAddressExternalFunction, EmitExternalFunction, InputsExternalFunction, OutputsExternalFunction, StorageLoadExternalFunction, StorageStoreExternalFunction};
 
 pub struct JsContract {
     runner: Arc<Mutex<WasmerRunner>>,
@@ -53,6 +49,9 @@ impl JsContract {
             let call_other_contract_tsfn = manager.call_other_contract_tsfn.clone();
             let deploy_from_address_tsfn = manager.deploy_from_address_tsfn.clone();
             let console_log_tsfn = manager.console_log_tsfn.clone();
+            let emit_tsfn = manager.emit_tsfn.clone();
+            let inputs_tsfn = manager.inputs_tsfn.clone();
+            let outputs_tsfn = manager.outputs_tsfn.clone();
 
             // Create ExternalFunction instances with contract_id
             let storage_load_external = StorageLoadExternalFunction::new(storage_load_tsfn, id);
@@ -60,6 +59,9 @@ impl JsContract {
             let call_other_contract_external = CallOtherContractExternalFunction::new(call_other_contract_tsfn, id);
             let deploy_from_address_external = DeployFromAddressExternalFunction::new(deploy_from_address_tsfn, id);
             let console_log_external = ConsoleLogExternalFunction::new(console_log_tsfn, id);
+            let emit_external = EmitExternalFunction::new(emit_tsfn, id);
+            let inputs_external = InputsExternalFunction::new(inputs_tsfn, id);
+            let outputs_external = OutputsExternalFunction::new(outputs_tsfn, id);
 
             // Obtain a Runtime from the pool
             let runtime = manager
@@ -75,6 +77,9 @@ impl JsContract {
                 call_other_contract_external,
                 deploy_from_address_external,
                 console_log_external,
+                emit_external,
+                inputs_external,
+                outputs_external,
                 runtime.clone(),
             ).map_err(|e| Error::from_reason(format!("{:?}", e)))?;
 

--- a/src/interfaces/napi/js_contract_manager.rs
+++ b/src/interfaces/napi/js_contract_manager.rs
@@ -47,6 +47,12 @@ pub struct ContractManager {
     pub deploy_from_address_tsfn: ThreadsafeFunction<ThreadSafeJsImportResponse, ErrorStrategy::CalleeHandled>,
     #[napi(skip)]
     pub console_log_tsfn: ThreadsafeFunction<ThreadSafeJsImportResponse, ErrorStrategy::CalleeHandled>,
+    #[napi(skip)]
+    pub emit_tsfn: ThreadsafeFunction<ThreadSafeJsImportResponse, ErrorStrategy::CalleeHandled>,
+    #[napi(skip)]
+    pub inputs_tsfn: ThreadsafeFunction<ThreadSafeJsImportResponse, ErrorStrategy::CalleeHandled>,
+    #[napi(skip)]
+    pub outputs_tsfn: ThreadsafeFunction<ThreadSafeJsImportResponse, ErrorStrategy::CalleeHandled>,
 }
 
 #[napi]
@@ -71,15 +77,30 @@ impl ContractManager {
         )]
         deploy_from_address_js_function: JsFunction,
         #[napi(
-            ts_arg_type = "(_: never, result: ThreadSafeJsImportResponse) => Promise<void>"
+            ts_arg_type = "(_: never, result: ThreadSafeJsImportResponse) => void"
         )]
         console_log_js_function: JsFunction,
+        #[napi(
+            ts_arg_type = "(_: never, result: ThreadSafeJsImportResponse) => void"
+        )]
+        emit_js_function: JsFunction,
+        #[napi(
+            ts_arg_type = "(_: never) => Promise<Buffer | Uint8Array>"
+        )]
+        inputs_js_function: JsFunction,
+        #[napi(
+            ts_arg_type = "(_: never) => Promise<Buffer | Uint8Array>"
+        )]
+        outputs_js_function: JsFunction,
     ) -> Result<Self, Error> {
         let storage_load_tsfn = create_tsfn!(storage_load_js_function);
         let storage_store_tsfn = create_tsfn!(storage_store_js_function);
         let call_other_contract_tsfn = create_tsfn!(call_other_contract_js_function);
         let deploy_from_address_tsfn = create_tsfn!(deploy_from_address_js_function);
         let console_log_tsfn = create_tsfn!(console_log_js_function);
+        let emit_tsfn = create_tsfn!(emit_js_function);
+        let inputs_tsfn = create_tsfn!(inputs_js_function);
+        let outputs_tsfn = create_tsfn!(outputs_js_function);
 
         let max_idling_runtimes = max_idling_runtimes as usize;
 
@@ -95,6 +116,9 @@ impl ContractManager {
             deploy_from_address_tsfn,
             console_log_tsfn,
             runtime_pool,
+            emit_tsfn,
+            inputs_tsfn,
+            outputs_tsfn,
         })
     }
 
@@ -161,8 +185,6 @@ impl ContractManager {
         abort_tsfn!(self.call_other_contract_tsfn, &env);
         abort_tsfn!(self.deploy_from_address_tsfn, &env);
         abort_tsfn!(self.console_log_tsfn, &env);
-
-        //self.runtime_pool.destroy();
 
         Ok(())
     }

--- a/src/interfaces/napi/js_contract_manager.rs
+++ b/src/interfaces/napi/js_contract_manager.rs
@@ -185,6 +185,9 @@ impl ContractManager {
         abort_tsfn!(self.call_other_contract_tsfn, &env);
         abort_tsfn!(self.deploy_from_address_tsfn, &env);
         abort_tsfn!(self.console_log_tsfn, &env);
+        abort_tsfn!(self.emit_tsfn, &env);
+        abort_tsfn!(self.inputs_tsfn, &env);
+        abort_tsfn!(self.outputs_tsfn, &env);
 
         Ok(())
     }

--- a/src/interfaces/napi/js_contract_manager.rs
+++ b/src/interfaces/napi/js_contract_manager.rs
@@ -85,11 +85,11 @@ impl ContractManager {
         )]
         emit_js_function: JsFunction,
         #[napi(
-            ts_arg_type = "(_: never) => Promise<Buffer | Uint8Array>"
+            ts_arg_type = "(_: never, result: ThreadSafeJsImportResponse) => Promise<Buffer | Uint8Array>"
         )]
         inputs_js_function: JsFunction,
         #[napi(
-            ts_arg_type = "(_: never) => Promise<Buffer | Uint8Array>"
+            ts_arg_type = "(_: never, result: ThreadSafeJsImportResponse) => Promise<Buffer | Uint8Array>"
         )]
         outputs_js_function: JsFunction,
     ) -> Result<Self, Error> {


### PR DESCRIPTION
Your contracts will now have access to the following things:
- Transaction object:
 1. Bitcoin transactions inputs (on request, gas optimized)
 2. Bitcoin transaction outputs (on request, gas optimized)
 3. Transaction hash
 4. Sender
 5. Origin
- Block object:
 1. number (u256)
 2. number (u64)
 3. hash (Uint8Array)
 4. Time median (u64)
 5. randU64 (deterministic)
- ripemd160
- no more abi forced
- no more "readView", this is now merged with readMethod which is now called "execute"
- no more selector forced
- onInstanciated is now onDeployment which take optional calldata as parameter
- events are now emitted as created