### PR TITLE
Add dynamic gas calculation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@btc-vision/op-vm",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@btc-vision/op-vm",
-            "version": "0.2.6",
+            "version": "0.2.7",
             "hasInstallScript": true,
             "license": "LICENSE.MD",
             "dependencies": {

--- a/src/domain/runner/constants/constants.rs
+++ b/src/domain/runner/constants/constants.rs
@@ -5,7 +5,13 @@ pub const PAGE_MEMORY_SIZE: u64 = 64 * 1024;
 pub const MAX_MEMORY_SIZE: u64 = (MAX_PAGES as u64) * PAGE_MEMORY_SIZE;
 
 /** Gas cost for custom functions */
-pub const LOAD_COST: u64 = 40_000_000;
+pub const LOAD_COLD: u64 = 2_100_000;
+pub const LOAD_WARM: u64 = 100_000;
+pub const STORE_BASE: u64 = 100_000;
+pub const STORE_NEW: u64 = 20_000_000;
+pub const STORE_UPDATE: u64 = 2_900_000;
+pub const STORE_REFUND: u64 = 4_800_000;
+
 pub const STORE_COST: u64 = 80_000_000;
 pub const STORE_REFUND_ZERO: u64 = 30_000_000;
 
@@ -21,7 +27,6 @@ pub const OUTPUTS_COST: u64 = 5_000_000;
 pub const EMIT_COST: u64 = 1_000_000;
 pub const IS_VALID_BITCOIN_ADDRESS_COST: u64 = 1_000_000;
 pub const SCHNORR_VERIFICATION_COST: u64 = 100_000_000;
-
 
 /** Constraints */
 pub const MAX_LENGTH_BUFFER_EXTERN: u32 = 2 * 1024 * 1024; // 4MB

--- a/src/domain/runner/custom_env.rs
+++ b/src/domain/runner/custom_env.rs
@@ -5,7 +5,6 @@ use crate::interfaces::{
     DeployFromAddressExternalFunction, EmitExternalFunction, InputsExternalFunction,
     OutputsExternalFunction, StorageLoadExternalFunction, StorageStoreExternalFunction,
 };
-use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::runtime::Runtime;
 
@@ -22,8 +21,7 @@ pub struct CustomEnv {
     pub inputs_external: InputsExternalFunction,
     pub outputs_external: OutputsExternalFunction,
     pub runtime: Arc<Runtime>,
-
-    pub refunded_pointers: Mutex<HashMap<Vec<u8>, bool>>,
+    pub store_cache: Mutex<super::store::Cache>,
 }
 
 impl CustomEnv {
@@ -52,7 +50,7 @@ impl CustomEnv {
             inputs_external,
             outputs_external,
             runtime,
-            refunded_pointers: Mutex::new(HashMap::new()),
+            store_cache: Mutex::new(super::store::Cache::new()),
         })
     }
 }

--- a/src/domain/runner/import_functions.rs
+++ b/src/domain/runner/import_functions.rs
@@ -11,8 +11,8 @@ use wasmer::{FunctionEnvMut, RuntimeError, StoreMut};
 use crate::domain::assembly_script::AssemblyScript;
 use crate::domain::runner::{
     exported_import_functions, AbortData, CustomEnv, InstanceWrapper, CALL_COST, DEPLOY_COST,
-    EMIT_COST, INPUTS_COST, IS_VALID_BITCOIN_ADDRESS_COST, LOAD_COST, OUTPUTS_COST, RIMD160_COST,
-    SCHNORR_VERIFICATION_COST, SHA256_COST, STORE_COST, STORE_REFUND_ZERO,
+    EMIT_COST, INPUTS_COST, IS_VALID_BITCOIN_ADDRESS_COST, OUTPUTS_COST, RIMD160_COST,
+    SCHNORR_VERIFICATION_COST, SHA256_COST,
 };
 use crate::interfaces::ExternalFunction;
 
@@ -45,15 +45,7 @@ pub fn storage_load_import(
     ptr: u32,
 ) -> Result<u32, RuntimeError> {
     let (env, store) = context.data_and_store_mut();
-    load_pointer_external_import(
-        env,
-        store,
-        &env.storage_load_external,
-        ptr,
-        LOAD_COST,
-        &env.runtime,
-        &env.refunded_pointers,
-    )
+    load_pointer_external_import(env, store, ptr, &env.runtime)
 }
 
 pub fn storage_store_import(
@@ -61,15 +53,7 @@ pub fn storage_store_import(
     ptr: u32,
 ) -> Result<u32, RuntimeError> {
     let (env, store) = context.data_and_store_mut();
-    store_pointer_external_import(
-        env,
-        store,
-        &env.storage_store_external,
-        ptr,
-        STORE_COST,
-        &env.runtime,
-        STORE_REFUND_ZERO,
-    )
+    store_pointer_external_import(env, store, ptr, &env.runtime)
 }
 
 pub fn call_other_contract_import(
@@ -355,7 +339,7 @@ fn verify_gas_refund_eligibility(
         if !is_refunded {
             map.insert(pointer, true);
 
-            instance.refund_gas(store, refund_if_zero_result);
+            instance.refund_gas(store, refund_if_zero_result as i64);
         }
     }
 
@@ -365,40 +349,38 @@ fn verify_gas_refund_eligibility(
 fn load_pointer_external_import(
     env: &CustomEnv,
     mut store: StoreMut,
-    external_function: &impl ExternalFunction,
     ptr: u32,
-    gas_cost: u64,
     runtime: &Runtime,
-    refunded_pointers: &Mutex<HashMap<Vec<u8>, bool>>,
 ) -> Result<u32, RuntimeError> {
     let instance = env
         .instance
         .clone()
         .ok_or(RuntimeError::new("Instance not found"))?;
 
-    instance.use_gas(&mut store, gas_cost);
-
     let data = AssemblyScript::read_buffer(&mut store, &instance, ptr)
         .map_err(|_e| RuntimeError::new("Error lifting typed array"))?;
-
-    let result = external_function.execute(&data, runtime)?;
-
-    // Mutate the HashMap
-    let mut map = refunded_pointers
+    let mut cache = env
+        .store_cache
         .lock()
-        .map_err(|e| RuntimeError::new(format!("Error locking refunded pointers: {}", e)))?;
+        .map_err(|e| RuntimeError::new(format!("Error claiming store cache: {}", e)))?;
 
-    if !have_only_zero_bytes(&result) {
-        let pointer = safe_slice(&data, 0, 32)
-            .ok_or(RuntimeError::new("Invalid buffer"))?
-            .to_vec();
+    // Get method
+    let result = cache.get(
+        &data
+            .try_into()
+            .map_err(|e| RuntimeError::new(format!("Cannot convert the pointer: {:?}", e)))?,
+        |key| {
+            Ok(env
+                .storage_load_external
+                .execute(&key, runtime)?
+                .try_into()
+                .map_err(|e| RuntimeError::new(format!("Cannot map result to data: {:?}", e)))?)
+        },
+    )?;
 
-        if !map.contains_key(&pointer) {
-            map.insert(pointer, false);
-        }
-    }
+    instance.use_gas(&mut store, result.gas_cost);
 
-    let value = AssemblyScript::write_buffer(&mut store, &instance, &result, 13, 0)
+    let value = AssemblyScript::write_buffer(&mut store, &instance, &result.value, 13, 0)
         .map_err(|e| RuntimeError::new(format!("Error writing buffer: {}", e)))?;
 
     Ok(value as u32)
@@ -417,11 +399,10 @@ fn import_external_call(
         .clone()
         .ok_or(RuntimeError::new("Instance not found"))?;
 
-    instance.use_gas(&mut store, gas_cost);
-
     let data = AssemblyScript::read_buffer(&mut store, &instance, ptr)
         .map_err(|_e| RuntimeError::new("Error lifting typed array"))?;
 
+    instance.use_gas(&mut store, gas_cost);
     let result = external_function.execute(&data, runtime)?;
     let value = AssemblyScript::write_buffer(&mut store, &instance, &result, 13, 0)
         .map_err(|e| RuntimeError::new(format!("Error writing buffer: {}", e)))?;
@@ -432,18 +413,17 @@ fn import_external_call(
 fn store_pointer_external_import(
     env: &CustomEnv,
     mut store: StoreMut,
-    external_function: &impl ExternalFunction,
     ptr: u32,
-    gas_cost: u64,
     runtime: &Runtime,
-    refund_if_zero_result: u64,
 ) -> Result<u32, RuntimeError> {
     let instance = env
         .instance
         .clone()
         .ok_or(RuntimeError::new("Instance not found"))?;
-
-    instance.use_gas(&mut store, gas_cost);
+    let mut cache = env
+        .store_cache
+        .lock()
+        .map_err(|e| RuntimeError::new(format!("Error claiming store cache: {}", e)))?;
 
     let data = AssemblyScript::read_buffer(&mut store, &instance, ptr)
         .map_err(|_e| RuntimeError::new("Error lifting typed array"))?;
@@ -459,20 +439,35 @@ fn store_pointer_external_import(
         .ok_or(RuntimeError::new("Invalid buffer"))?
         .to_vec();
 
-    let result = external_function.execute(&data, runtime)?;
+    let result = cache.set(
+        pointer
+            .try_into()
+            .map_err(|e| RuntimeError::new(format!("Cannot convert the pointer: {:?}", e)))?,
+        value
+            .try_into()
+            .map_err(|e| RuntimeError::new(format!("Cannot convert the pointer: {:?}", e)))?,
+        |key| {
+            Ok(env
+                .storage_load_external
+                .execute(&key, runtime)?
+                .try_into()
+                .map_err(|e| RuntimeError::new(format!("Cannot map result to data: {:?}", e)))?)
+        },
+        |key, value| {
+            env.storage_store_external
+                .execute(
+                    &key.iter().chain(value.iter()).cloned().collect::<Vec<u8>>(),
+                    runtime,
+                )
+                .map_err(|e| RuntimeError::new(format!("Cannot map result to data: {:?}", e)))?;
+            Ok(())
+        },
+    )?;
 
-    // Optionally verify refund eligibility
-    if refund_if_zero_result > 0 && have_only_zero_bytes(&value) {
-        verify_gas_refund_eligibility(
-            &env.refunded_pointers,
-            &instance,
-            &mut store,
-            refund_if_zero_result,
-            pointer.clone(),
-        )?;
-    }
+    instance.use_gas(&mut store, result.gas_cost);
+    instance.refund_gas(&mut store, result.gas_refund as i64);
 
-    let value = AssemblyScript::write_buffer(&mut store, &instance, &result, 13, 0)
+    let value = AssemblyScript::write_buffer(&mut store, &instance, &result.value, 13, 0)
         .map_err(|e| RuntimeError::new(format!("Error writing buffer: {}", e)))?;
 
     Ok(value as u32)

--- a/src/domain/runner/mod.rs
+++ b/src/domain/runner/mod.rs
@@ -4,11 +4,12 @@ pub use self::{
 };
 
 mod abort_data;
+mod bitcoin_network;
+mod constants;
 mod contract_runner;
 mod custom_env;
 mod exported_import_functions;
-mod instance_wrapper;
-mod wasmer_runner;
-mod bitcoin_network;
-mod constants;
 mod import_functions;
+mod instance_wrapper;
+mod store;
+mod wasmer_runner;

--- a/src/domain/runner/store.rs
+++ b/src/domain/runner/store.rs
@@ -1,0 +1,387 @@
+use super::constants::{
+    LOAD_COLD, LOAD_WARM, STORE_BASE, STORE_COST, STORE_NEW, STORE_REFUND, STORE_UPDATE,
+};
+use tokio::runtime::Runtime;
+use wasmer::RuntimeError;
+
+pub const STORAGE_POINTER_SIZE: usize = 32;
+pub const STORAGE_VALUE_SIZE: usize = 32;
+pub type StoragePointer = [u8; STORAGE_POINTER_SIZE];
+pub type StorageValue = [u8; STORAGE_VALUE_SIZE];
+pub const STORAGE_VALUE_ZERO: [u8; STORAGE_VALUE_SIZE] = [0; STORAGE_VALUE_SIZE];
+
+pub struct CacheResponse {
+    pub value: StorageValue,
+    pub gas_cost: u64,
+    pub gas_refund: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct CacheValue {
+    original: StorageValue,
+    current: StorageValue,
+}
+
+impl CacheValue {
+    // New value filled from existing store
+    pub fn new(value: StorageValue) -> Self {
+        Self {
+            original: value,
+            current: value,
+        }
+    }
+
+    // New value created in same transaction
+    pub fn new_created(value: StorageValue) -> Self {
+        Self {
+            original: STORAGE_VALUE_ZERO,
+            current: value,
+        }
+    }
+
+    pub fn is_changed(&self) -> bool {
+        self.original == self.current
+    }
+}
+
+impl CacheResponse {
+    pub fn new(value: [u8; STORAGE_VALUE_SIZE], gas_cost: u64, gas_refund: i64) -> Self {
+        Self {
+            value,
+            gas_cost,
+            gas_refund,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Cache {
+    values: std::collections::HashMap<[u8; STORAGE_POINTER_SIZE], CacheValue>,
+    reads: usize,
+    writes: usize,
+}
+
+impl Cache {
+    pub fn new() -> Self {
+        Self {
+            values: std::collections::HashMap::new(),
+            reads: 0,
+            writes: 0,
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn exists(&self, pointer: &[u8; STORAGE_POINTER_SIZE]) -> bool {
+        self.values.contains_key(pointer)
+    }
+
+    pub fn get<GetFun>(
+        &mut self,
+        pointer: &[u8; STORAGE_POINTER_SIZE],
+        get_fn: GetFun,
+    ) -> Result<CacheResponse, RuntimeError>
+    where
+        GetFun: Fn(StoragePointer) -> Result<StorageValue, RuntimeError>,
+    {
+        self.reads += 1;
+
+        // If object exists in the cache
+        if let Some(value) = self.values.get(pointer) {
+            Ok(CacheResponse::new(value.current, LOAD_WARM, 0))
+        }
+        // first acces of pointer
+        else {
+            let original_value = get_fn(*pointer)?;
+            self.values
+                .insert(*pointer, CacheValue::new(original_value));
+
+            Ok(CacheResponse::new(original_value, LOAD_COLD, 0))
+        }
+    }
+
+    pub fn set<GetFun, SetFun>(
+        &mut self,
+        key: [u8; STORAGE_POINTER_SIZE],
+        value: [u8; STORAGE_VALUE_SIZE],
+        get_value: GetFun,
+        set_value: SetFun,
+    ) -> Result<CacheResponse, RuntimeError>
+    where
+        GetFun: Fn(StoragePointer) -> Result<StorageValue, RuntimeError>,
+        SetFun: Fn(StoragePointer, StorageValue) -> Result<(), RuntimeError>,
+    {
+        // increase number of writes
+        self.writes += 1;
+
+        let mut gas_cost = 0;
+        let mut gas_refund: i64 = 0;
+
+        let mut cache_value = if let Some(value) = self.values.get(&key) {
+            // Warm access
+            value.clone()
+        } else {
+            // Cold access
+            gas_cost += LOAD_COLD;
+            CacheValue::new(get_value(key)?)
+        };
+
+        if value == cache_value.current {
+            // No changes
+            gas_cost += STORE_BASE;
+        } else {
+            // Clean slot (not yet updated in current execution context)
+            if cache_value.original == cache_value.current {
+                // (slot started zero, currently still zero, now being changed to nonzero)
+                if cache_value.original == STORAGE_VALUE_ZERO {
+                    gas_cost += STORE_NEW;
+                }
+                // (slot started nonzero, currently still same nonzero value, now being changed):
+                else {
+                    gas_cost += STORE_UPDATE;
+                }
+            } else {
+                gas_cost += STORE_BASE
+            };
+
+            if cache_value.current == cache_value.original {
+                if cache_value.original != STORAGE_VALUE_ZERO && value == STORAGE_VALUE_ZERO {
+                    gas_refund = STORE_REFUND as i64;
+                }
+            } else {
+                if cache_value.original != STORAGE_VALUE_ZERO {
+                    if cache_value.current == STORAGE_VALUE_ZERO {
+                        // TODO: Add to gas???
+                        if value != cache_value.original {
+                            gas_refund -= STORE_REFUND as i64;
+                        } else {
+                            gas_refund -= (2_100_000 as i64) - (LOAD_WARM as i64);
+                        }
+                    } else if value == STORAGE_VALUE_ZERO {
+                        gas_refund = STORE_REFUND as i64;
+                    }
+                } else if cache_value.original == value {
+                    if cache_value.original == STORAGE_VALUE_ZERO {
+                        gas_refund = (STORE_NEW as i64) - (STORE_BASE as i64);
+                    } else {
+                        gas_refund =
+                            (STORE_REFUND as i64) - (LOAD_COLD as i64) + (LOAD_WARM as i64);
+                    }
+                }
+            }
+
+            // Set value to store
+            cache_value.current = value;
+            set_value(key, value)?;
+            self.values.insert(key, cache_value);
+        }
+
+        Ok(CacheResponse::new(value, gas_cost, gas_refund))
+    }
+
+    #[allow(dead_code)]
+    pub fn reset(&mut self) {
+        self.values.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Cache, CacheValue, StoragePointer, StorageValue};
+    use std::{
+        collections::HashMap,
+        sync::{Arc, Mutex},
+    };
+
+    const POINTER: super::StoragePointer = [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+        25, 26, 27, 28, 29, 30, 31,
+    ];
+
+    fn create_store(
+        pointer: Option<StoragePointer>,
+        original_value: Option<StorageValue>,
+        current_value: Option<StorageValue>,
+    ) -> (
+        Cache,
+        Arc<Mutex<HashMap<super::StoragePointer, super::StorageValue>>>,
+    ) {
+        let pointer = pointer.unwrap_or([1; super::STORAGE_POINTER_SIZE]);
+        let store: Arc<Mutex<HashMap<StoragePointer, StorageValue>>> = if original_value.is_some() {
+            Arc::new(Mutex::new(HashMap::from_iter([(
+                pointer,
+                original_value.unwrap(),
+            )])))
+        } else {
+            Arc::new(Mutex::new(HashMap::new()))
+        };
+
+        let cache = if current_value.is_some() {
+            Cache {
+                reads: 0,
+                writes: 0,
+                values: HashMap::from_iter([(
+                    pointer,
+                    CacheValue {
+                        original: original_value.unwrap_or(super::STORAGE_VALUE_ZERO),
+                        current: current_value.unwrap(),
+                    },
+                )]),
+            }
+        } else {
+            Cache::new()
+        };
+
+        (cache, store)
+    }
+
+    #[test]
+    pub fn test_cold_write_zero() {
+        let value = [0; 32];
+
+        let (mut cache, store) = create_store(Some(POINTER), None, None);
+        let get_fn = |key: super::StoragePointer| {
+            Ok(store
+                .lock()
+                .unwrap()
+                .get(&key)
+                .unwrap_or(&super::STORAGE_VALUE_ZERO)
+                .clone())
+        };
+        let set_fn = |key: super::StoragePointer, value: super::StorageValue| {
+            store.lock().unwrap().insert(key, value);
+            Ok(())
+        };
+
+        cache.get(&POINTER, get_fn).unwrap();
+
+        let result = cache.set(POINTER, value, get_fn, set_fn).unwrap();
+
+        assert_eq!(result.gas_cost, 100_000);
+    }
+
+    #[test]
+    pub fn test_get_value() {
+        let value = [10; 32];
+
+        let (mut cache, store) = create_store(Some(POINTER), Some(value), None);
+        let get_fn = |key: super::StoragePointer| {
+            Ok(store
+                .lock()
+                .unwrap()
+                .get(&key)
+                .unwrap_or(&super::STORAGE_VALUE_ZERO)
+                .clone())
+        };
+
+        // Cold value
+        let result = cache.get(&POINTER, get_fn).unwrap();
+        assert_eq!(result.gas_cost, 2_100_000);
+        assert_eq!(result.value, value);
+
+        // Warm value
+        let result = cache.get(&POINTER, get_fn).unwrap();
+        assert_eq!(result.gas_cost, 100_000);
+        assert_eq!(result.value, value);
+    }
+
+    #[test]
+    pub fn test_set_value() {
+        let key = [
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, 26, 27, 28, 29, 30, 31,
+        ];
+
+        let (mut cache, store) = create_store(Some(key), None, None);
+        let get_fn = |key: super::StoragePointer| {
+            Ok(store
+                .lock()
+                .unwrap()
+                .get(&key)
+                .unwrap_or(&super::STORAGE_VALUE_ZERO)
+                .clone())
+        };
+        let set_fn = |key: super::StoragePointer, value: super::StorageValue| {
+            store.lock().unwrap().insert(key, value);
+            Ok(())
+        };
+
+        // New value / cold
+        let result = cache.set(key, [1; 32], get_fn, set_fn).unwrap();
+        assert_eq!(store.lock().unwrap().get(&key).unwrap(), &[1; 32]);
+
+        assert_eq!(result.gas_cost, 22_100_000);
+        assert_eq!(result.gas_refund, 0);
+
+        // Warm - not changed
+        let result = cache.set(key, [1; 32], get_fn, set_fn).unwrap();
+        assert_eq!(result.gas_cost, 100_000);
+        assert_eq!(result.gas_refund, 0);
+
+        cache.reset();
+
+        // cold - changed
+        let result = cache.set(key, [2; 32], get_fn, set_fn).unwrap();
+        assert_eq!(result.gas_cost, 5_000_000);
+        assert_eq!(result.gas_refund, 0);
+
+        // warm changed - after change
+        let result = cache.set(key, [3; 32], get_fn, set_fn).unwrap();
+        assert_eq!(result.gas_cost, 100_000);
+        assert_eq!(result.gas_refund, 0);
+
+        // Warm change
+        cache.reset();
+        let result = cache.get(&key, get_fn).unwrap();
+        assert_eq!(result.value, [3; 32]);
+
+        let result = cache.set(key, [4; 32], get_fn, set_fn).unwrap();
+        assert_eq!(result.gas_cost, 2_900_000);
+        assert_eq!(result.gas_refund, 0);
+
+        // Cold reset
+        cache.reset();
+        let result = cache.set(key, [0; 32], get_fn, set_fn).unwrap();
+        assert_eq!(result.gas_cost, 5_000_000);
+        assert_eq!(result.gas_refund, 4_800_000);
+
+        // warm reset
+        cache.set(key, [1; 32], get_fn, set_fn).unwrap();
+        cache.reset();
+
+        let result = cache.get(&key, get_fn).unwrap();
+        assert_eq!(result.value, [1; 32]);
+
+        let result = cache.set(key, [0; 32], get_fn, set_fn).unwrap();
+        assert_eq!(result.gas_cost, 2_900_000);
+        assert_eq!(result.gas_refund, 4_800_000);
+
+        // Zero to default, change, default
+        cache.reset();
+        cache.set(key, [1; 32], get_fn, set_fn).unwrap();
+        let result = cache.set(key, [0; 32], get_fn, set_fn).unwrap();
+
+        assert_eq!(result.gas_cost, 100_000);
+        assert_eq!(result.gas_refund, 19_900_000);
+
+        // Value zero same value
+        cache.set(key, [1; 32], get_fn, set_fn).unwrap();
+        cache.reset();
+        cache.set(key, [0; 32], get_fn, set_fn).unwrap();
+
+        let result = cache.set(key, [1; 32], get_fn, set_fn).unwrap();
+        assert_eq!(result.gas_cost, 100_000);
+
+        // TODO: This values is not in formula: https://www.evm.codes/?fork=cancun#55
+        // but dialog calculation give this result
+        assert_eq!(result.gas_refund, -2_000_000);
+
+        // Value zero different value
+        cache.set(key, [1; 32], get_fn, set_fn).unwrap();
+        cache.reset();
+        cache.set(key, [0; 32], get_fn, set_fn).unwrap();
+        let result = cache.set(key, [2; 32], get_fn, set_fn).unwrap();
+
+        assert_eq!(result.gas_cost, 100_000);
+        assert_eq!(result.gas_refund, -4_800_000);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,9 @@ extern crate napi_derive;
 
 use std::panic;
 
+mod application;
 mod domain;
 mod interfaces;
-mod application;
 
 #[napi]
 pub fn init() {


### PR DESCRIPTION
Adds dynamic gas calculation based on Ethereum:
https://www.evm.codes/?fork=cancun#55

* Cold and Warm reads to cache
* Store method needs load for Cold read (gas is calculated correctly)
* Gas refund can be negative (due to set value after refund of reset) 
* Refunded pointers are replaced with the `store.Cache`

-------
Ethereum refunds gas at the end, our behavior is different

I am not sure if the cache (same as refunded pointers) is "fresh" before a transaction

Unit tests are only for Cache -> It Is not possible to pass `JsFunction`, due to the architecture of Napi and the external function interface.
