### PR TITLE
Take raw bytes from contract through imports instead of Uint8Array

### DIFF
--- a/src/domain/runner/call_result.rs
+++ b/src/domain/runner/call_result.rs
@@ -1,0 +1,12 @@
+#[derive(Default, Debug, Clone)]
+pub struct CallResult {
+    pub data: Vec<u8>,
+}
+
+impl CallResult {
+    pub fn new(data: &[u8]) -> Self {
+        Self {
+            data: data.to_vec(),
+        }
+    }
+}

--- a/src/domain/runner/constants/constants.rs
+++ b/src/domain/runner/constants/constants.rs
@@ -10,6 +10,7 @@ pub const STORE_COST: u64 = 80_000_000;
 pub const STORE_REFUND_ZERO: u64 = 30_000_000;
 
 pub const CALL_COST: u64 = 343_000_000;
+pub const CALL_RESULT_COST: u64 = 30_000;
 pub const DEPLOY_COST: u64 = 2_500_000_000;
 
 pub const SHA256_COST: u64 = 50_000;

--- a/src/domain/runner/custom_env.rs
+++ b/src/domain/runner/custom_env.rs
@@ -1,4 +1,5 @@
 use crate::domain::runner::bitcoin_network::BitcoinNetwork;
+use crate::domain::runner::call_result::CallResult;
 use crate::domain::runner::{AbortData, InstanceWrapper};
 use crate::interfaces::{
     CallOtherContractExternalFunction, ConsoleLogExternalFunction,
@@ -24,6 +25,7 @@ pub struct CustomEnv {
     pub runtime: Arc<Runtime>,
 
     pub refunded_pointers: Mutex<HashMap<Vec<u8>, bool>>,
+    pub last_call_result: CallResult,
 }
 
 impl CustomEnv {
@@ -53,6 +55,7 @@ impl CustomEnv {
             outputs_external,
             runtime,
             refunded_pointers: Mutex::new(HashMap::new()),
+            last_call_result: CallResult::default(),
         })
     }
 }

--- a/src/domain/runner/mod.rs
+++ b/src/domain/runner/mod.rs
@@ -4,11 +4,12 @@ pub use self::{
 };
 
 mod abort_data;
+mod bitcoin_network;
+mod call_result;
+mod constants;
 mod contract_runner;
 mod custom_env;
 mod exported_import_functions;
+mod import_functions;
 mod instance_wrapper;
 mod wasmer_runner;
-mod bitcoin_network;
-mod constants;
-mod import_functions;

--- a/src/domain/runner/wasmer_runner.rs
+++ b/src/domain/runner/wasmer_runner.rs
@@ -2,9 +2,7 @@ use bytes::Bytes;
 use chrono::Local;
 use std::sync::Arc;
 use wasmer::sys::{BaseTunables, EngineBuilder};
-use wasmer::{
-    imports, CompilerConfig, Function, FunctionEnv, Instance, Module, Store, Value,
-};
+use wasmer::{imports, CompilerConfig, Function, FunctionEnv, Instance, Module, Store, Value};
 use wasmer_compiler::types::target::Target;
 use wasmer_compiler::Engine;
 use wasmer_compiler_singlepass::Singlepass;
@@ -14,9 +12,10 @@ use wasmer_types::SerializeError;
 use crate::domain::assembly_script::AssemblyScript;
 use crate::domain::runner::{
     abort_import, call_other_contract_import, console_log_import, deploy_from_address_import,
-    emit_import, inputs_import, is_valid_bitcoin_address_import, outputs_import, ripemd160_import,
-    sha256_import, storage_load_import, storage_store_import, verify_schnorr_import, AbortData,
-    ContractRunner, CustomEnv, ExtendedMemoryAccessError, InstanceWrapper,
+    emit_import, get_call_result_import, inputs_import, is_valid_bitcoin_address_import,
+    outputs_import, ripemd160_import, sha256_import, storage_load_import, storage_store_import,
+    verify_schnorr_import, AbortData, ContractRunner, CustomEnv, ExtendedMemoryAccessError,
+    InstanceWrapper,
 };
 use crate::domain::vm::{get_gas_cost, log_time_diff, LimitingTunables};
 
@@ -111,6 +110,7 @@ impl WasmerRunner {
                 "load" => import!(storage_load_import),
                 "store" => import!(storage_store_import),
                 "call" => import!(call_other_contract_import),
+                "callResult" => import!(get_call_result_import),
                 "deployFromAddress" => import!(deploy_from_address_import),
                 "sha256" => import!(sha256_import),
                 "emit" => import!(emit_import),


### PR DESCRIPTION
Only for storage and call imports.